### PR TITLE
Delete checking on validity.valid prop of target in _onChangeHandler,…

### DIFF
--- a/src/editors/Number.js
+++ b/src/editors/Number.js
@@ -6,9 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import floatValidator from '../common/validation/validators/float';
 import utils from '../common/utils';
 import {findDOMNode} from 'react-dom';
 import React from 'react';
+
+const isInvalidFloat = floatValidator(null, null, true);
 
 class NumberEditor extends React.Component {
   static propTypes = {
@@ -31,12 +34,11 @@ class NumberEditor extends React.Component {
 
   _onChangeHandler(e) {
     const target = e.target;
-    const valueAsNumber = parseFloat(target.value);
-
-    if (!target.validity.valid) {
-      this.state.value = target.value;
-    } else if (target.value === '') {
+    const valueAsNumber = parseFloat(target.value); //not use target.valueAsNumber for IE compatibility
+    if (target.value === '' && target.validity.valid) { //check on validity.valid because string can be invalid
       this.state.value = null;
+    } else if (isInvalidFloat(valueAsNumber)) {
+      this.state.value = target.value;
     } else {
       this.state.value = valueAsNumber;
     }


### PR DESCRIPTION
When try to input in Editors.Number value that have more symbols after coma than in step prop, got a target.validity.valid = false.