### PR TITLE
number editor allow to insert only digits, +/- , dot and [e|E] symbols

### DIFF
--- a/src/editors/Number.js
+++ b/src/editors/Number.js
@@ -51,6 +51,14 @@ class NumberEditor extends React.Component {
     this.props.onChange(this.state.value);
   }
 
+  _onKeyPressHandler(e) {
+    const keyCode = e.keyCode || e.which;
+    const char = String.fromCharCode(keyCode);
+    if (!/\d|\+|-|[Ee]|\./.test(char)) {
+      e.preventDefault();
+    }
+  }
+
   render() {
     return (
       <input
@@ -59,6 +67,7 @@ class NumberEditor extends React.Component {
         type="number"
         ref="input"
         onChange={this::this._onChangeHandler}
+        onKeyPress={this::this._onKeyPressHandler}
         defaultValue={this.props.value}
       />
     );


### PR DESCRIPTION
https://trello.com/c/MASIoFpD/355-min-max-bid-fields-should-accept-only-digits