### PR TITLE
Added parameter `grid` to editor handler of columns config

### DIFF
--- a/docs/docs/grid-columns.md
+++ b/docs/docs/grid-columns.md
@@ -51,9 +51,10 @@ Columns list is specified as an object with column string IDs as keys and column
      * Function should return React component for editing value of the `editorField`.
      *
      * @param   {Object}           record    Record content
+     * @param   {Object}           grid      Grid context(this)
      * @return  {ReactComponent}
     **/
-    editor: function (record) { ... },
+    editor: function (record, grid) { ... },
 
     render: [
       {string}, ...,                // Fields, used for rendering

--- a/src/grid/mixins/editor.js
+++ b/src/grid/mixins/editor.js
@@ -92,7 +92,7 @@ const GridEditorMixin = {
     editorContext.props = props;
 
     // Display Editor
-    const Component = this.props.cols[column].editor.call(editorContext, record);
+    const Component = this.props.cols[column].editor.call(editorContext, record, this);
 
     if (!Component) {
       return;
@@ -124,7 +124,7 @@ const GridEditorMixin = {
     const record = this._getRecord(row);
     const context = utils.cloneDeep(editorContext);
     context.props.value = values;
-    const Component = this.props.cols[column].editor.call(context, record);
+    const Component = this.props.cols[column].editor.call(context, record, this);
     this.state.editor[`${row}_${column}`] = ReactDOM.render(Component, element);
 
     if (!Array.isArray(binds)) {


### PR DESCRIPTION
It is needed in cases when I wanna get some properties/methods of the grid when generating the editor, e.g. `grid.getModel()` (in case I wanna open a popup after a user selects a special value in the select editor)