### PR TITLE
Fixed bugs appeared after removing backwards compatibility with callbacks

### DIFF
--- a/src/common/callbackify.js
+++ b/src/common/callbackify.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (с) 2015-present, SoftIndex LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import utils from '../common/utils';
+
+const functionsNames = [];
+export default function (func, hideWarning = false) {
+  const funcName = func.name;
+
+  return function (...args) {
+    const lastArgumentIndex = args.length - 1;
+    const cb = args[lastArgumentIndex];
+
+    if (typeof cb === 'function' && !cb.__ignoreUIKernelWarning) {
+      if (!functionsNames.includes(funcName) && !hideWarning) {
+        utils.warn(`You are using callback in: '${funcName}'. Use promise instead.\n${JSON.stringify(args)}`);
+        functionsNames.push(funcName);
+      }
+
+      const result = func.apply(this, args);
+      if (result && result.then) {
+        result
+          .then(data => {
+            cb(null, data);
+          })
+          .catch(err => {
+            cb(err);
+          });
+      }
+    } else {
+      return func.apply(this, args);
+    }
+  };
+}

--- a/src/common/toPromise.js
+++ b/src/common/toPromise.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (с) 2015-present, SoftIndex LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import utils from '../common/utils';
+
+const functionsNames = [];
+
+function toPromise(func, hideWarning) {
+  const funcName = func.name;
+
+  function warn(text) {
+    if (!hideWarning) {
+      if (!functionsNames.includes(funcName)) {
+        utils.warn(text);
+        functionsNames.push(funcName);
+      }
+    }
+  }
+
+  return function (...mainArguments) {
+    let promise;
+    const callbackPromise = new Promise((resolve, reject) => {
+      function toPromiseCallback(err, data) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(data);
+      }
+      toPromiseCallback.__ignoreUIKernelWarning = true;
+      mainArguments.push(toPromiseCallback);
+      promise = func(...mainArguments);
+    });
+
+    if (promise) {
+      if (promise.then && promise.catch) {
+        return promise;
+      }
+      warn(
+        `The return value is not a Promise in '${funcName}'.\n` +
+        `Arguments: ${JSON.stringify(mainArguments)}\n` +
+        `Returns: ${JSON.stringify(promise)}`
+      );
+      return callbackPromise;
+    } else {
+      warn(
+        `You are using callback in: '${funcName}'. Use promise instead.\n` +
+        `Arguments: ${JSON.stringify(mainArguments)}`
+      );
+      return callbackPromise;
+    }
+  };
+}
+
+export default toPromise;

--- a/src/editors/SuggestBox.js
+++ b/src/editors/SuggestBox.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import toPromise from '../common/toPromise';
 import utils from '../common/utils';
 import Portal from '../common/Portal';
 import {findDOMNode} from 'react-dom';
@@ -190,7 +191,7 @@ class SuggestBoxEditor extends React.Component {
       return;
     }
 
-    await this.setState({
+    await toPromise(::this.setState, true)({
       isOpened: true,
       loading: true,
       popupStyles: this._setPopupStyles()

--- a/src/form/mixin.js
+++ b/src/form/mixin.js
@@ -7,8 +7,10 @@
  */
 
 import utils from '../common/utils';
+import toPromise from '../common/toPromise';
 import Validator from '../common/validation/validators/common';
 import ValidationErrors from '../common/validation/ValidationErrors';
+import callbackify from '../common/callbackify';
 
 /**
  * Grid form mixin
@@ -55,8 +57,9 @@ const FormMixin = {
    * @param {bool}              [settings.autoSubmit]                   Automatic submit before updateField
    * @param {Function}          [settings.autoSubmitHandler]            Automatic submit handler
    * @param {Validator}         [settings.warningsValidator]            Warningss validator for fields
+   * @param {Function}          [cb]                                    CallBack function
    */
-  async initForm(settings) {
+  initForm: callbackify(async function (settings) {
     this._initState(settings);
 
     if (!this.state._formMixin.data) {
@@ -74,7 +77,7 @@ const FormMixin = {
 
       if (err) {
         this.state._formMixin.globalError = err;
-        await this.setState(this.state);
+        await toPromise(::this.setState, true)(this.state);
         throw err;
       }
 
@@ -82,11 +85,11 @@ const FormMixin = {
     }
 
     this.state._formMixin.model.on('update', this._handleModelChange);
-    await this.setState(this.state);
+    await toPromise(::this.setState, true)(this.state);
     if (!settings.partialErrorChecking) {
       await this.validateForm();
     }
-  },
+  }, true),
 
   /**
    * Check is data loaded
@@ -317,7 +320,7 @@ const FormMixin = {
    * Set data in the form
    *
    * @param {Object}    data              Data
-   * @param {bool}      [validate=false]  Validate form
+   * @param {boolean}      [validate=false]  Validate form
    * @param {Function}  [cb]              CallBack
    */
   set: function (data, validate, cb) {
@@ -365,7 +368,7 @@ const FormMixin = {
    *
    * @param {Function}  [cb]  CallBack function
    */
-  submit: async function () {
+  submit: callbackify(async function () {
     if (this._isNotInitialized()) {
       return;
     }
@@ -426,13 +429,13 @@ const FormMixin = {
       }, this);
     }
 
-    await this.setState(this.state);
+    await toPromise(::this.setState, true)(this.state);
 
     if (err) {
       throw err;
     }
     return data;
-  },
+  }),
 
   clearFieldChanges: function (field, cb) {
     if (this._isNotInitialized()) {

--- a/src/grid/export/exporters/toCSV.js
+++ b/src/grid/export/exporters/toCSV.js
@@ -6,10 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import toPromise from '../../../common/toPromise';
 import csv from 'csv-stringify';
 
 async function toCSV(data) {
-  const csvData = await csv(data.records.concat([data.totals]), {
+  const csvData = await toPromise(csv, true)(data.records.concat([data.totals]), {
     header: true,
     columns: data.columns
   });

--- a/src/grid/mixins/ui.js
+++ b/src/grid/mixins/ui.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import toPromise from '../../common/toPromise';
 import utils from '../../common/utils';
 import {findDOMNode} from 'react-dom';
 import React from 'react';
@@ -129,7 +130,7 @@ const GridUIMixin = {
     const extra = this._dataArrayToObject(obj.extraRecords || []);
     const recordIds = Object.keys(data.records).concat(Object.keys(extra.records));
 
-    await this.setState({
+    await toPromise(this.setState.bind(this), true)({
       data: Object.assign({}, data.records, extra.records),
       mainIds: Object.keys(data.records),
       count: obj.count,


### PR DESCRIPTION
We can't remove **toPromise** at all because sometimes it's needed to setState synchronously and React provides only a callback for it.
We can't remove **callbackify** yet because it's used for backwards compatibility with the old API in legacy parts like FormMixin.
We can't remove **throttleCallback** yet because is still used in FormMixin._validateForm.

\+ there was several bugs in code like `await this.setState`
