### PR TITLE
fixed bug https://trello.com/c/1d9WSRav/906-editable-grid-sort-bugs, …

### DIFF
--- a/src/grid/mixins/ui.js
+++ b/src/grid/mixins/ui.js
@@ -136,7 +136,7 @@ const GridUIMixin = {
 
     await toPromise(this.setState.bind(this), true)({
       data: Object.assign({}, data.records, extra.records),
-      mainIds: Object.keys(data.records),
+      mainIds: recordIds,
       count: obj.count,
       totals: obj.totals,
       recordsInfo: Object.assign({}, extra.info, data.info),


### PR DESCRIPTION
…when changes in editable grid was on first page, but their ids wasn't in mainIds. tandem fixing with 77b8fe909 on node.networks.