### PR TITLE
Fix incorrect setState logic in _setRecordData during update

### DIFF
--- a/src/grid/Component.js
+++ b/src/grid/Component.js
@@ -897,17 +897,20 @@ class GridComponent extends React.Component {
       return;
     }
 
-    const nextData = new EqualMap([...this.state.data].map(([dataRecordId, record]) => {
-      if (!isEqual(recordId, dataRecordId)) {
-        return [dataRecordId, record];
-      }
+    this.setState((state) => {
+      state.data = new EqualMap([...state.data].map(([dataRecordId, record]) => {
+        if (!isEqual(recordId, dataRecordId)) {
+          return [dataRecordId, record];
+        }
+  
+        return [dataRecordId, {
+          ...record,
+          ...data
+        }];
+      }));
 
-      return [dataRecordId, {
-        ...record,
-        ...data
-      }];
-    }));
-    this.setState({data: nextData});
+      return state;
+    });
   }
 
   /**


### PR DESCRIPTION
The problem was that during update with multiple records the state for update of the last record has been taken from this.state and due to running it in loop it wasn't relevant - the state update from previous records hasn't been applied yet at the moment of reading this.state.data.